### PR TITLE
Remove uncut parent requirement

### DIFF
--- a/convexml/_iid_exponential_mle.py
+++ b/convexml/_iid_exponential_mle.py
@@ -545,11 +545,6 @@ class IIDExponentialMLE(BranchLengthEstimator):
                                     "descends from "
                                     f"{character_states_dict[u][i]}."
                                 )
-                    elif character_states[i] == 0 and parent_states[i] != 0:
-                        raise Exception(
-                            "If a node has state 0 (uncut), its parent should "
-                            "also have state 0."
-                        )
         return long_edge_mutations
 
     @staticmethod


### PR DESCRIPTION
@sprillo can we remove the requirement that for all uncut nodes the parent is also uncut? With accurate ancestral state inferences on real world data this is impossible to satisfy due to noise in the character matrix. For example, if a mutation occurs in an ancestral cell and we sample 1000 of that cell's descendants in the phylogeny, even with a ~.1% error rate we will likely call that character as uncut in at least one descendant. 